### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ end
 ```ruby
 
 require 'rack/app'
+require 'rack/app/front_end' # You need to add `gem 'rack-app-front_end'` to your Gemfile
 
 class App < Rack::App
 
@@ -158,11 +159,12 @@ class App < Rack::App
   validate_params do
     required 'words', :class => Array, :of => String, :desc => 'some word', :example => ['pug']
     optional 'word', :class => String, :desc => 'one word', :example => 'pug'
+    optional 'boolean', :class => :boolean, :desc => 'boolean value', :example => true
   end
   get '/hello' do
-    puts(validate_params['words'])
+    puts(params['words'])
 
-    return 'Hello World!'
+    'Hello World!'
   end
 
   namespace '/users' do
@@ -223,7 +225,7 @@ describe App do
 
   describe '/hello' do
     # example for params and headers and payload use
-    subject{ get(url: '/hello', params: {'dog' => 'meat'}, headers: {'X-Cat' => 'fur'}, payload: 'some string') }
+    subject { get(url: '/hello', params: {'dog' => 'meat'}, headers: {'X-Cat' => 'fur'}, payload: 'some string') }
 
     it { expect(subject.status).to eq 200 }
 
@@ -232,7 +234,7 @@ describe App do
 
   describe '/users/:user_id' do
     # restful endpoint example
-    subject{ get(url: '/users/1234') }
+    subject { get(url: '/users/1234') }
 
     it { expect(subject.body).to eq 'hello 1234!'}
 
@@ -242,7 +244,7 @@ describe App do
 
   describe '/make_error' do
     # error handled example
-    subject{ get(url: '/make_error') }
+    subject { get(url: '/make_error') }
 
     it { expect(subject.body).to eq '{:error=>"error block rescued"}' }
   end


### PR DESCRIPTION
Hi! :wave: Thanks for the gem :smile: 
Some information in documentation is incorrect and requires a little source code digging.

* A little style improvements
* Example of how to use `boolean` values in params validation. It's not obvious and not readme, nor site documentation specifies this
* Fix typo in `validated_params`. This one bugs me. In documentation you use as an example `validated_params`. However no such method exists and judging by implementation of `params`, it shouldn't. I've replaced it with `params`, which seems more appropriate. Gists on site documentation should be also updated as well, I believe